### PR TITLE
Add Modular Forms to libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,7 @@
 - [hooked-head](https://github.com/JoviDeCroock/hooked-head) - Hooks to manipulate the `<head>` section of the DOM. This has a subpackage with core preact support (using `preact/hooks`).
 - [Teaful](https://github.com/teafuljs/teaful) - Tiny (800B), easy and powerful (P)React state management.
 - [Nano Stores](https://github.com/nanostores/nanostores) - A tiny (199 bytes) state manager with many atomic tree-shakable stores.
+- [Modular Forms](https://github.com/fabian-hiller/modular-forms) - Modular, type-safe and signal based form library for Preact.
 
 
 ### Testing Utils


### PR DESCRIPTION
I added my form library called [Modular Forms](https://modularforms.dev/) to readme.md

### Checklist
- [x] My contribution hasn't been previously submitted.
- [x] My contribution description is short and simple, but descriptive.
- [x] My contribution follows the format: `[Title Case Name](link) - Description.`.