### PR TITLE
Add pretch to Related Libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@
 - [Modular Forms](https://github.com/fabian-hiller/modular-forms) - Modular, type-safe and signal based form library for Preact.
 - [exome](https://github.com/Marcisbee/exome) - Simple proxy based state manager for deeply nested states.
 - [Fastro](https://fastro.deno.dev) - Fast & Modular SSR Web Framework for Deno, TypeScript, Preact & Tailwind.
-- [pretch](https://github.com/EGAMAGZ/pretch) - A lightweight and flexible fetch enhancement library that works with vanilla JavaScript, React, and Preact
+- [Pretch](https://github.com/EGAMAGZ/pretch) - A lightweight and flexible fetch enhancement library that works with vanilla JavaScript, React, and Preact
 
 
 ### Testing Utils

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@
 - [Modular Forms](https://github.com/fabian-hiller/modular-forms) - Modular, type-safe and signal based form library for Preact.
 - [exome](https://github.com/Marcisbee/exome) - Simple proxy based state manager for deeply nested states.
 - [Fastro](https://fastro.deno.dev) - Fast & Modular SSR Web Framework for Deno, TypeScript, Preact & Tailwind.
+- [pretch](https://github.com/EGAMAGZ/pretch) - A lightweight and flexible fetch enhancement library that works with vanilla JavaScript, React, and Preact
 
 
 ### Testing Utils


### PR DESCRIPTION
A library that enhances and customizes fetch behavior without modifying the global fetch. It works seamlessly with vanilla JavaScript (@pretch/core), React (@pretch/react), and Preact (@pretch/preact).

Specifically for @pretch/preact, this is a library of hooks designed to integrate @pretch/core with Preact, simplifying fetch usage while providing customizable behavior to enhance its functionality.

Repo: https://github.com/EGAMAGZ/pretch
Docs: https://jsr.io/@pretch/preact
JSR: https://jsr.io/@pretch/preact

### Checklist
- [X] My contribution hasn't been previously submitted.
- [X] My contribution description is short and simple, but descriptive.
- [X] My contribution follows the format: `[Title Case Name](link) - Description.`.