### PR TITLE
Add Authier to Example Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,7 @@
 - [Trellith](https://trellith.sakih.net/) - Tiny Trello Clone PWA ([GitHub Project](https://github.com/sakihet/trellith)).
 - [Gladys Assistant](https://gladysassistant.com/) - A privacy-first, open-source home assistant _([GitHub Project](https://github.com/GladysAssistant/Gladys))_.
 - [Lanquiz](https://codeberg.org/nykula/lanquiz) - Host quizzes in LAN from a laptop (Import from Kahoot. Self-host during blackouts).
+- [Authier](https://www.authier.pm/) - Open-source password manager with Preact-powered autofill and password-generation interfaces in its browser extension *([GitHub Project](https://github.com/authier-pm/authier))*.
 
 ### Related Libraries
 - [React](https://github.com/facebook/react) - A declarative, efficient, and flexible JavaScript library for building user interfaces.


### PR DESCRIPTION
## Summary

- Add Authier to the Example Apps section.
- Link its canonical homepage and public source repository.
- Describe the browser extension's production Preact use for autofill and password-generation interfaces.

The released `v1.2.10-extension` source declares Preact 10.29.8 and compiles the shipped content-script TSX with `jsxImportSource: 'preact'`.

## Validation

- `git diff --check`
- Confirmed this is the only Authier entry and the only changed file.
- Confirmed both submitted URLs return HTTP 200 without redirects.
- `npx awesome-lint` introduces no new diagnostics; the unchanged upstream baseline and this branch both report 11 warnings and 51 errors.

### Checklist

- [x] My contribution hasn't been previously submitted.
- [x] My contribution description is short and simple, but descriptive.
- [x] My contribution follows the format: `[Title Case Name](link) - Description.`.

## Disclosure

I maintain Authier. AI assisted with research and preparation of this contribution. Authier is early-stage and has not undergone an independent security audit.
